### PR TITLE
Modified import location for ByteFmt

### DIFF
--- a/s3-benchmark.go
+++ b/s3-benchmark.go
@@ -16,7 +16,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
-	"github.com/pivotal-golang/bytefmt"
+	"code.cloudfoundry.org/bytefmt"
 	"io"
 	"io/ioutil"
 	"log"


### PR DESCRIPTION
RE: https://github.com/cloudfoundry/bytefmt

Note: This repository should be imported as code.cloudfoundry.org/bytefmt.

Corrects build failure.
