### PR TITLE
runDownload: make objnum a function of upload_count

### DIFF
--- a/s3-benchmark.go
+++ b/s3-benchmark.go
@@ -238,7 +238,7 @@ func runUpload(thread_num int) {
 func runDownload(thread_num int) {
 	for time.Now().Before(endtime) {
 		atomic.AddInt32(&download_count, 1)
-		objnum := rand.Int31n(download_count) + 1
+		objnum := rand.Int31n(upload_count) + 1
 		prefix := fmt.Sprintf("%s/%s/Object-%d", url_host, bucket, objnum)
 		req, _ := http.NewRequest("GET", prefix, nil)
 		setSignature(req)


### PR DESCRIPTION
The actual number of uploaded objects corresponds to upload_count, and
therefore objnum should be a function of upload_count (download_count
typically exceeds upload_count and it does not make any sense to
attempt to download objects there were never uploaded).